### PR TITLE
Add mod-specific gui button settings for IPN

### DIFF
--- a/overrides/config/inventoryprofilesnext/integrationHints/ae2.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/ae2.json
@@ -1,0 +1,75 @@
+{
+    "appeng.client.gui.implementations.ChestScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.CondenserScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.DriveScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.InscriberScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 47,
+                "top": -8
+            }
+        }
+    },
+    "appeng.client.gui.implementations.InterfaceScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.MolecularAssemblerScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.PatternProviderScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.SpatialAnchorScreen": {
+        "ignore": true
+    },
+    "appeng.menu.implementations.SpatialAnchorMenu": {
+        "ignore": true
+    },
+    "appeng.client.gui.implementations.VibrationChamberScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.QNBScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.me.common.MEStorageScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 20
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 20
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 20
+            }
+        }
+    },
+    "appeng.client.gui.implementations.IOBusScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.WirelessScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.SecurityStationScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 20
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 20
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 20
+            }
+        }
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/astralsorcery.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/astralsorcery.json
@@ -1,0 +1,57 @@
+{
+    "hellfirepvp.astralsorcery.client.screen.container.ScreenContainerAltarRadiance": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            }
+        }
+    },
+    "hellfirepvp.astralsorcery.client.screen.container.ScreenContainerAltarConstellation": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            }
+        }
+    },
+    "hellfirepvp.astralsorcery.client.screen.container.ScreenContainerAltarAttunement": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -2,
+                "bottom": -15
+            }
+        }
+    },
+    "hellfirepvp.astralsorcery.client.screen.container.ScreenContainerAltarDiscovery": {
+        "ignore": true,
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/chiselsandbits.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/chiselsandbits.json
@@ -1,0 +1,22 @@
+{
+    "mod.chiselsandbits.client.screens.ModificationTableScreen": {
+        "playerSideOnly": true
+    },
+    "mod.chiselsandbits.client.screens.ChiseledPrinterScreen": {
+        "playerSideOnly": true
+    },
+    "mod.chiselsandbits.client.screens.BitBagScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -1
+            },
+            "SORT_COLUMNS": {
+                "bottom": -1
+            },
+            "SORT_ROWS": {
+                "bottom": -1
+            }
+        }
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/cyclic.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/cyclic.json
@@ -1,0 +1,320 @@
+{
+    "com.lothrazar.cyclic.block.collectitem.ScreenItemCollector": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": 21
+            },
+            "SORT_COLUMNS": {
+                "bottom": 21
+            },
+            "SORT_ROWS": {
+                "bottom": 21
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.peatfarm.ScreenPeatFarm": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.battery.ScreenBattery": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.harvester.ScreenHarvester": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.anvil.ScreenAnvil": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.placer.ScreenPlacer": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.shapebuilder.ScreenStructure": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 20,
+                "bottom": 21
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 20,
+                "bottom": 21
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 20,
+                "bottom": 21
+            },
+            "SHOW_EDITOR": {
+                "top": -1
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.melter.ScreenMelter": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.solidifier.ScreenSolidifier": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.breaker.ScreenBreaker": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.expcollect.ScreenExpPylon": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.user.ScreenUser": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.disenchant.ScreenDisenchant": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.wireless.redstone.ScreenTransmit": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.clock.ScreenClock": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": 9
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -3
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -15
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.crate.ScreenCrate": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": -18,
+                "bottom": -12
+            },
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": -18,
+                "top": 38
+            },
+            "SORT": {
+                "horizontalOffset": -54,
+                "top": 2
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -42,
+                "top": 14
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -30,
+                "top": 26
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.placerfluid.ScreenPlacerFluid": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 20
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 20
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 20
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.collectfluid.ScreenFluidCollect": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.fan.ScreenFan": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.beaconpotion.ScreenPotion": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.dropper.ScreenDropper": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.forester.ScreenForester": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.miner.ScreenMiner": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.screen.ScreenScreentext": {
+        "ignore": true
+    },
+    "com.lothrazar.cyclic.block.screen.ContainerScreentext": {
+        "ignore": true
+    },
+    "com.lothrazar.cyclic.block.anvilmagma.ScreenAnvilMagma": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.uncrafter.ScreenUncraft": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.crafter.ScreenCrafter": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": 21
+            },
+            "SORT_COLUMNS": {
+                "bottom": 21
+            },
+            "SORT_ROWS": {
+                "bottom": 21
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.shapedata.ScreenShapedata": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -25
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -38
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.workbench.ScreenWorkbench": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.fishing.ScreenFisher": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.laser.ScreenLaser": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": 21
+            },
+            "SORT_COLUMNS": {
+                "bottom": 21
+            },
+            "SORT_ROWS": {
+                "bottom": 21
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.anvilvoid.ScreenAnvilVoid": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.wireless.energy.ScreenWirelessEnergy": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.wireless.item.ScreenWirelessItem": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.wireless.fluid.ScreenWirelessFluid": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.generatorfuel.ScreenGeneratorFuel": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.generatorfood.ScreenGeneratorFood": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.generatoritem.ScreenGeneratorDrops": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.generatorfluid.ScreenGeneratorFluid": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.packager.ScreenPackager": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.soundrecord.ScreenSoundRecorder": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 2
+            },
+            "SORT": {
+                "horizontalOffset": 35
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 35
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 35
+            }
+        }
+    },
+    "com.lothrazar.cyclic.block.soundplay.ScreenSoundPlayer": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.crusher.ScreenCrusher": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.tp.ScreenTeleport": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.cyclic.block.generatorpeat.ScreenGeneratorPeat": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/exampleIntegrationHints.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/exampleIntegrationHints.json
@@ -1,46 +1,47 @@
 {
-  "package.name.className": {
-    "ignore": false,
-    "playerSideOnly": false,
-    "force": false,
-    "buttonHints": {
-      "SORT": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0
-      },
-      "SORT_COLUMNS": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0
-      },
-      "SORT_ROWS": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0
-      },
-      "MOVE_TO_CONTAINER": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0
-      },
-      "MOVE_TO_PLAYER": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0
-      },
-      "CONTINUOUS_CRAFTING": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0
-      },
-      "PROFILE_SELECTOR": {
-        "horizontalOffset": 0,
-        "top": 0,
-        "bottom": 0,
-        "hide": true
-      }
+    "package.name.className":         {
+        "ignore":         false,
+        "playerSideOnly": false,
+        "force":          false,
+        "buttonHints":    {
+            "SORT":                {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0
+            },
+            "SORT_COLUMNS":        {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0
+            },
+            "SORT_ROWS":           {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0
+            },
+            "MOVE_TO_CONTAINER":   {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0
+            },
+            "MOVE_TO_PLAYER":      {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0
+            },
+            "CONTINUOUS_CRAFTING": {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0
+            },
+            "PROFILE_SELECTOR":    {
+                "horizontalOffset": 0,
+                "top":              0,
+                "bottom":           0,
+                "hide":             true
+            }
+        }
+    },
+    "another.package.name.className": {
     }
-  },
-  "another.package.name.className": {}
 }

--- a/overrides/config/inventoryprofilesnext/integrationHints/extendedcrafting.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/extendedcrafting.json
@@ -1,0 +1,76 @@
+{
+    "com.blakebr0.extendedcrafting.client.screen.CraftingCoreScreen": {
+        "playerSideOnly": true
+    },
+    "com.blakebr0.extendedcrafting.client.screen.BasicTableScreen": {
+        "playerSideOnly": true
+    },
+    "com.blakebr0.extendedcrafting.client.screen.AdvancedTableScreen": {
+        "playerSideOnly": true
+    },
+    "com.blakebr0.extendedcrafting.client.screen.EliteTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 12
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 12
+            }
+        }
+    },
+    "com.blakebr0.extendedcrafting.client.screen.UltimateTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 27
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 27
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 27
+            }
+        }
+    },
+    "com.blakebr0.extendedcrafting.client.screen.BasicAutoTableScreen": {
+        "playerSideOnly": true
+    },
+    "com.blakebr0.extendedcrafting.client.screen.AdvancedAutoTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 5
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 5
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 5
+            }
+        }
+    },
+    "com.blakebr0.extendedcrafting.client.screen.EliteAutoTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 22
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 22
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 22
+            }
+        }
+    },
+    "com.blakebr0.extendedcrafting.client.screen.CompressorScreen": {
+        "playerSideOnly": true
+    },
+    "com.blakebr0.extendedcrafting.client.screen.EnderCrafterScreen": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/farmingforblockheads.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/farmingforblockheads.json
@@ -1,0 +1,20 @@
+{
+    "net.blay09.mods.farmingforblockheads.client.gui.screen.MarketScreen": {
+        "ignore": true,
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -40,
+                "bottom": -10
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -28,
+                "bottom": -22
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -16,
+                "bottom": -34
+            }
+        }
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/immersiveengineering.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/immersiveengineering.json
@@ -1,0 +1,175 @@
+{
+    "blusunrize.immersiveengineering.client.gui.CraftingTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -1
+            },
+            "SORT_COLUMNS": {
+                "bottom": -1
+            },
+            "SORT_ROWS": {
+                "bottom": -1
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.SorterScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -6
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -18
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -30
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.ItemBatcherScreen": {
+        "playerSideOnly": true
+    },
+    "blusunrize.immersiveengineering.client.gui.LogicUnitScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -2
+            },
+            "SORT_COLUMNS": {
+                "bottom": -2
+            },
+            "SORT_ROWS": {
+                "bottom": -2
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.GunTurretScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -25
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -37
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.common.gui.TurretContainer$GunTurretContainer": {
+        "ignore": true
+    },
+    "blusunrize.immersiveengineering.client.gui.ChemTurretScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -25
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -37
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.common.gui.TurretContainer$ChemTurretContainer": {
+        "ignore": true
+    },
+    "blusunrize.immersiveengineering.client.gui.ClocheScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -25
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -37
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.common.gui.ClocheContainer": {
+        "ignore": true
+    },
+    "blusunrize.immersiveengineering.client.gui.ModWorkbenchScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -2
+            },
+            "SORT_COLUMNS": {
+                "bottom": -2
+            },
+            "SORT_ROWS": {
+                "bottom": -2
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.CircuitTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 16,
+                "bottom": 1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 28,
+                "bottom": -11
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 40,
+                "bottom": -23
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.FluidSorterScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -6
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -18
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -30
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.ToolboxScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -2
+            },
+            "SORT_COLUMNS": {
+                "bottom": -2
+            },
+            "SORT_ROWS": {
+                "bottom": -2
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.RevolverScreen": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/integrateddynamics.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/integrateddynamics.json
@@ -1,0 +1,41 @@
+{
+    "org.cyclops.integrateddynamics.inventory.container.ContainerPartReader": {
+        "ignore": true
+    },
+    "org.cyclops.integrateddynamics.inventory.container.ContainerPartPanelVariableDriven": {
+        "ignore": true
+    },
+    "org.cyclops.integrateddynamics.inventory.container.ContainerPartWriter": {
+        "ignore": true
+    },
+    "org.cyclops.integratedterminals.client.gui.container.ContainerScreenTerminalStorage": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 20
+            },
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": 2,
+                "top": 21
+            },
+            "SORT": {
+                "horizontalOffset": -10,
+                "top": 5
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -10,
+                "top": 5
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -10,
+                "top": 5
+            },
+            "SHOW_EDITOR": {
+                "horizontalOffset": 28,
+                "top": -5
+            }
+        }
+    },
+    "org.cyclops.integratedcrafting.inventory.container.ContainerPartInterfaceCrafting": {
+        "ignore": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/ironchest.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/ironchest.json
@@ -1,0 +1,21 @@
+{
+    "com.progwml6.ironchest.client.screen.IronChestScreen": {
+        "buttonHints": {
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": 4
+            },
+            "SORT": {
+                "horizontalOffset": 4
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 4
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 4
+            },
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 4
+            }
+        }
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/mekanism.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/mekanism.json
@@ -1,0 +1,105 @@
+{
+    "mekanism.common.inventory.container.tile.MekanismTileContainer": {
+        "ignore": true
+    },
+    "mekanism.client.gui.machine.GuiDigitalMinerConfig": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.qio.GuiPortableQIODashboard": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -14
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -26
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -38
+            }
+        }
+    },
+    "mekanism.client.gui.machine.GuiAdvancedElectricMachine": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiElectricMachine": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiCombiner": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiDigitalMiner": {
+        "force": true
+    },
+    "mekanism.client.gui.machine.GuiMetallurgicInfuser": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiElectricPump": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.GuiPersonalChestTile": {
+        "force": true
+    },
+    "mekanism.common.registration.impl.ContainerTypeDeferredRegister$ContainerBuilder$1": {
+        "ignore": true
+    },
+    "mekanism.client.gui.machine.GuiPrecisionSawmill": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiSeismicVibrator": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiPRC": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.GuiFluidTank": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiFluidicPlenisher": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.GuiLaserAmplifier": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.GuiLaserTractorBeam": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiOredictionificator": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiResistiveHeater": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiFuelwoodHeater": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.GuiModificationStation": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -1
+            },
+            "SORT_COLUMNS": {
+                "bottom": -1
+            },
+            "SORT_ROWS": {
+                "bottom": -1
+            }
+        }
+    },
+    "mekanism.client.gui.machine.GuiAntiprotonicNucleosynthesizer": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.machine.GuiPaintingMachine": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.qio.GuiQIODriveArray": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.GuiEnergyCube": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/player-defined.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/player-defined.json
@@ -1,0 +1,899 @@
+{
+    "net.minecraft.client.gui.screen.inventory.CreativeScreen": {
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 47,
+                "top": -8
+            }
+        }
+    },
+    "net.minecraft.client.gui.screen.inventory.InventoryScreen": {
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 47,
+                "top": -8
+            }
+        }
+    },
+    "net.minecraft.client.gui.screen.inventory.CraftingScreen": {
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 47,
+                "top": -8
+            }
+        }
+    },
+    "net.minecraft.client.gui.screen.inventory.ChestScreen": {
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 47,
+                "top": -8
+            }
+        }
+    },
+    "appeng.client.gui.me.items.ItemTerminalScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SHOW_EDITOR": {
+                "horizontalOffset": 47,
+                "top": -8
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            }
+        }
+    },
+    "com.almostreliable.lazierae2.gui.MachineScreen": {
+        "ignore": true
+    },
+    "shadows.apotheosis.village.fletching.FletchingScreen": {
+        "ignore": true
+    },
+    "appeng.client.gui.implementations.SkyChestScreen": {
+        "buttonHints": {
+            "MOVE_TO_PLAYER": {
+                "top": 6
+            },
+            "SORT": {
+                "top": 6
+            },
+            "SORT_COLUMNS": {
+                "top": 6
+            },
+            "SORT_ROWS": {
+                "top": 6
+            }
+        }
+    },
+    "appeng.client.gui.implementations.GrinderScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.SpatialIOPortScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.fluids.client.gui.FluidInterfaceScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.CellWorkbenchScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.IOPortScreen": {
+        "playerSideOnly": true
+    },
+    "tfar.ae2wt.wirelesscraftingterminal.WirelessCraftingTerminalScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 24,
+                "bottom": 22
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 24,
+                "bottom": 22
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 24,
+                "bottom": 22
+            }
+        }
+    },
+    "tfar.ae2wt.wpt.WirelessPatternTerminalScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            }
+        }
+    },
+    "tfar.ae2wt.wirelessinterfaceterminal.WITScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            }
+        }
+    },
+    "appeng.client.gui.implementations.StorageBusScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.fluids.client.gui.FluidStorageBusScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.fluids.client.gui.FluidIOBusScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.implementations.LevelEmitterScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.fluids.client.gui.FluidLevelEmitterScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.me.items.PatternTermScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            }
+        }
+    },
+    "appeng.client.gui.me.items.CraftingTermScreen": {
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            },
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 19
+            },
+            "CONTINUOUS_CRAFTING": {
+                "horizontalOffset": 62,
+                "bottom": -12
+            }
+        }
+    },
+    "appeng.client.gui.me.interfaceterminal.InterfaceTerminalScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            }
+        }
+    },
+    "appeng.client.gui.me.fluids.FluidTerminalScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 19
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 19
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 19
+            }
+        }
+    },
+    "net.bullfighter.avaritia.gui.NeutronCollectorGuiGuiWindow": {
+        "playerSideOnly": true
+    },
+    "net.bullfighter.avaritia.gui.NeutroniumCompressorGuiGuiWindow": {
+        "playerSideOnly": true
+    },
+    "net.bullfighter.avaritia.gui.ExtremeCraftingTableGuiGuiWindow": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 2,
+                "bottom": 2
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 2,
+                "bottom": 2
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 2,
+                "bottom": 2
+            }
+        }
+    },
+    "thetestmod.bettercrates.gui.GuiBase9Rows": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": -18,
+                "bottom": -12
+            },
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": -18
+            },
+            "SORT": {
+                "horizontalOffset": -54,
+                "top": 12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -42,
+                "top": 24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -30,
+                "top": 36
+            }
+        }
+    },
+    "thetestmod.bettercrates.gui.GuiBase13Rows": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 22,
+                "bottom": -12
+            },
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": -18
+            },
+            "SORT": {
+                "horizontalOffset": -54,
+                "top": 12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -42,
+                "top": 24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -30,
+                "top": 36
+            }
+        }
+    },
+    "wayoftime.bloodmagic.client.screens.ScreenSoulForge": {
+        "playerSideOnly": true
+    },
+    "wayoftime.bloodmagic.client.screens.ScreenAlchemicalReactionChamber": {
+        "playerSideOnly": true
+    },
+    "wayoftime.bloodmagic.client.screens.ScreenAlchemyTable": {
+        "playerSideOnly": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiGenerator": {
+        "ignore": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiGrinder": {
+        "ignore": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiEnergyTransfuser": {
+        "ignore": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiDraconiumChest": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 140,
+                "bottom": -15
+            },
+            "MOVE_TO_PLAYER": {
+                "top": -16
+            },
+            "SORT": {
+                "top": -16
+            },
+            "SORT_COLUMNS": {
+                "top": -16
+            },
+            "SORT_ROWS": {
+                "top": -16
+            }
+        }
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiFlowGate": {
+        "ignore": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiFusionCraftingCore": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 21,
+                "bottom": -1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 21,
+                "bottom": -1
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 21,
+                "bottom": -1
+            }
+        }
+    },
+    "codechicken.enderstorage.client.gui.GuiEnderItemStorage": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "bottom": -1
+            }
+        }
+    },
+    "com.valkyrieofnight.envirotech.m_voidminer.ui.VoidMinerGUI": {
+        "ignore": true
+    },
+    "com.blakebr0.extendedcrafting.client.screen.UltimateAutoTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 39
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 39
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 39
+            },
+            "SHOW_EDITOR": {
+                "horizontalOffset": -1
+            }
+        }
+    },
+    "blusunrize.immersiveengineering.client.gui.ToolboxBlockScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -2
+            },
+            "SORT_COLUMNS": {
+                "bottom": -2
+            },
+            "SORT_ROWS": {
+                "bottom": -2
+            }
+        }
+    },
+    "com.hrznstudio.titanium.client.screen.container.BasicAddonScreen": {
+        "ignore": true,
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 146,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 158,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 170,
+                "bottom": -36
+            },
+            "SHOW_EDITOR": {
+                "horizontalOffset": 5
+            }
+        }
+    },
+    "knightminer.inspirations.building.client.ShelfScreen": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "bottom": -1
+            }
+        }
+    },
+    "mekanism.client.gui.machine.GuiFactory": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -25
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -37
+            }
+        }
+    },
+    "mekanism.client.gui.item.GuiPersonalChestItem": {
+        "buttonHints": {
+            "MOVE_TO_PLAYER": {
+                "top": 9
+            },
+            "SORT": {
+                "top": 9
+            },
+            "SORT_COLUMNS": {
+                "top": 9
+            },
+            "SORT_ROWS": {
+                "top": 9
+            }
+        }
+    },
+    "mekanism.client.gui.machine.GuiFormulaicAssemblicator": {
+        "playerSideOnly": true
+    },
+    "mekanism.client.gui.qio.GuiQIODashboard": {
+        "ignore": true
+    },
+    "mob_grinding_utils.inventory.client.GuiFan": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": 74
+            },
+            "SORT_COLUMNS": {
+                "bottom": 74
+            },
+            "SORT_ROWS": {
+                "bottom": 74
+            }
+        }
+    },
+    "mob_grinding_utils.inventory.client.GuiSaw": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": 92
+            },
+            "SORT_COLUMNS": {
+                "bottom": 92
+            },
+            "SORT_ROWS": {
+                "bottom": 92
+            }
+        }
+    },
+    "mob_grinding_utils.inventory.client.GuiAbsorptionHopper": {
+        "playerSideOnly": true
+    },
+    "mob_grinding_utils.inventory.client.GuiMGUSpawner": {
+        "playerSideOnly": true
+    },
+    "com.alc.moreminecarts.client.ChunkLoaderScreen": {
+        "playerSideOnly": true
+    },
+    "com.alc.moreminecarts.client.FlagCartScreen": {
+        "playerSideOnly": true
+    },
+    "com.alc.moreminecarts.client.TankCartScreen": {
+        "playerSideOnly": true
+    },
+    "com.alc.moreminecarts.client.BatteryCartScreen": {
+        "playerSideOnly": true
+    },
+    "com.alc.moreminecarts.client.MinecartUnLoaderScreen": {
+        "playerSideOnly": true
+    },
+    "com.mrcrayfish.furniture.client.gui.screen.inventory.CrateScreen": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "bottom": -1
+            }
+        }
+    },
+    "com.mrcrayfish.furniture.client.gui.screen.inventory.FreezerScreen": {
+        "playerSideOnly": true
+    },
+    "corgiaoc.byg.client.gui.screens.HypogealImperiumScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiElevator": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiSecurityStationInventory": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiFluidTank": {
+        "ignore": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiSmartChest": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 46,
+                "bottom": -8
+            },
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": 4
+            },
+            "SORT": {
+                "horizontalOffset": 4
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 4
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 4
+            }
+        }
+    },
+    "owmii.powah.client.screen.container.EnergyCellScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.EnderCellScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.FurnatorScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.MagmatorScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.ThermoScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.SolarScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.ReactorScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.PlayerTransmitterScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.EnergyHopperScreen": {
+        "ignore": true
+    },
+    "owmii.powah.client.screen.container.DischargerScreen": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.crafter.client.GuiCrafter": {
+        "ignore": true
+    },
+    "net.geforcemods.securitycraft.screen.KeycardReaderScreen": {
+        "playerSideOnly": true
+    },
+    "com.jaquadro.minecraft.storagedrawers.inventory.DrawerScreen$Slot1": {
+        "playerSideOnly": true
+    },
+    "com.jaquadro.minecraft.storagedrawers.inventory.DrawerScreen$Slot2": {
+        "playerSideOnly": true
+    },
+    "com.jaquadro.minecraft.storagedrawers.inventory.DrawerScreen$Slot4": {
+        "playerSideOnly": true
+    },
+    "com.jaquadro.minecraft.storagedrawers.inventory.DrawerScreen$Compacting": {
+        "playerSideOnly": true
+    },
+    "slimeknights.tconstruct.tables.client.inventory.TinkerChestScreen": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "bottom": -1
+            }
+        }
+    },
+    "slimeknights.tconstruct.smeltery.client.inventory.HeatingStructureScreen": {
+        "ignore": true
+    },
+    "slimeknights.tconstruct.smeltery.client.inventory.MelterScreen": {
+        "ignore": true
+    },
+    "slimeknights.mantle.client.screen.BackgroundContainerScreen": {
+        "ignore": true
+    },
+    "com.lothrazar.cyclic.item.crafting.CraftingBagScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "com.lothrazar.cyclic.item.craftingsimple.CraftingStickScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "com.teammetallurgy.atum.client.gui.block.GodforgeScreen": {
+        "playerSideOnly": true
+    },
+    "superlord.prehistoricfauna.client.render.tileentity.gui.PaleontologyTableScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -36
+            }
+        }
+    },
+    "superlord.prehistoricfauna.client.render.tileentity.gui.PaleoscribeScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "bottom": -1
+            },
+            "SORT_COLUMNS": {
+                "bottom": -1
+            },
+            "SORT_ROWS": {
+                "bottom": -1
+            }
+        }
+    },
+    "cy.jdkdigital.productivebees.container.gui.AdvancedBeehiveScreen": {
+        "ignore": true,
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -29,
+                "bottom": -16
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -17,
+                "bottom": -28
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -5,
+                "bottom": -40
+            }
+        }
+    },
+    "androsa.gaiadimension.block.inventory.AgateCraftingScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 1
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 1
+            }
+        }
+    },
+    "androsa.gaiadimension.block.inventory.SmallCrateScreen": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "bottom": -1
+            }
+        }
+    },
+    "androsa.gaiadimension.block.inventory.LargeCrateScreen": {
+        "buttonHints": {
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 8
+            },
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": 8
+            },
+            "SORT": {
+                "horizontalOffset": 8
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 8
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 8
+            }
+        }
+    },
+    "androsa.gaiadimension.block.inventory.GaiaStoneFurnaceScreen": {
+        "playerSideOnly": true
+    },
+    "androsa.gaiadimension.block.inventory.RestructurerScreen": {
+        "playerSideOnly": true
+    },
+    "androsa.gaiadimension.block.inventory.PurifierScreen": {
+        "playerSideOnly": true
+    },
+    "com.the9grounds.aeadditions.client.gui.me.chemical.ChemicalTerminalScreen": {
+        "playerSideOnly": true
+    },
+    "com.the9grounds.aeadditions.client.gui.me.chemical.ChemicalIOBusScreen": {
+        "playerSideOnly": true
+    },
+    "com.valkyrieofnight.envirocore.m_machines.m_mem_progrm.ui.client.MemProgrmGui": {
+        "playerSideOnly": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.modular.GuiModularItem": {
+        "playerSideOnly": true
+    },
+    "com.the9grounds.aeadditions.client.gui.me.chemical.ChemicalInterfaceScreen": {
+        "playerSideOnly": true
+    },
+    "com.refinedmods.refinedpipes.screen.ExtractorAttachmentScreen": {
+        "ignore": true,
+        "playerSideOnly": true
+    },
+    "net.mrscauthd.boss_tools.gui.screens.nasaworkbench.NasaWorkbenchGuiWindow": {
+        "playerSideOnly": true
+    },
+    "net.mrscauthd.boss_tools.gui.screens.solarpanel.SolarPanelGuiWindow": {
+        "ignore": true
+    },
+    "net.mrscauthd.boss_tools.gui.screens.coalgenerator.CoalGeneratorGuiWindow": {
+        "playerSideOnly": true
+    },
+    "net.mrscauthd.boss_tools.gui.screens.blastfurnace.BlastFurnaceGuiWindow": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 1,
+                "bottom": 3
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 1,
+                "bottom": 3
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 1,
+                "bottom": 3
+            }
+        }
+    },
+    "net.mrscauthd.boss_tools.gui.screens.compressor.CompressorGuiWindow": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 1
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 1
+            }
+        }
+    },
+    "net.mrscauthd.boss_tools.gui.screens.fuelrefinery.FuelRefineryGuiWindow": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 1
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 1
+            }
+        }
+    },
+    "net.mrscauthd.boss_tools.gui.screens.oxygenloader.OxygenLoaderGuiWindow": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 1
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 1
+            }
+        }
+    },
+    "net.mrscauthd.boss_tools.gui.screens.oxygenbubbledistributor.OxygenBubbleDistributorGuiWindow": {
+        "ignore": true
+    },
+    "net.mrscauthd.boss_tools.gui.screens.waterpump.WaterPumpGuiWindow": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 1
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 1
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 1
+            }
+        }
+    },
+    "net.mrscauthd.boss_tools.gui.screens.rover.RoverGuiWindow": {
+        "playerSideOnly": true
+    },
+    "net.mrscauthd.boss_tools.gui.screens.rocket.RocketGuiWindow": {
+        "playerSideOnly": true
+    },
+    "com.lothrazar.storagenetwork.item.remote.GuiNetworkCraftingRemote": {
+        "playerSideOnly": true
+    },
+    "com.brandon3055.draconicevolution.client.gui.GuiEnergyCore": {
+        "ignore": true
+    },
+    "com.mrcrayfish.furniture.client.gui.screen.inventory.MailBoxScreen": {
+        "playerSideOnly": true
+    },
+    "tfar.dankstorage.client.screens.DockScreen": {
+        "playerSideOnly": true
+    },
+    "appeng.client.gui.me.items.PatternEncodingTermScreen": {
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 31
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 31
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 31
+            },
+            "MOVE_TO_CONTAINER": {
+                "horizontalOffset": 19,
+                "bottom": -12
+            },
+            "CONTINUOUS_CRAFTING": {
+                "horizontalOffset": 81,
+                "bottom": -10
+            }
+        }
+    },
+    "appeng.menu.me.items.CraftingTermMenu": {
+        "playerSideOnly": true
+    },
+    "appeng.menu.me.items.PatternEncodingTermMenu": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/pneumaticcraft.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/pneumaticcraft.json
@@ -1,0 +1,546 @@
+{
+    "me.desht.pneumaticcraft.client.gui.GuiAdvancedAirCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiAdvancedLiquidCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiAerialInterface": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiAirCannon": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiAirCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiAssemblyController": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiChargingStation": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiElectrostaticCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiFluxCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiGasLift": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiKeroseneLamp": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiLiquidCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiLiquidHopper": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiOmnidirectionalHopper": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiPneumaticDoorBase": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiPneumaticDynamo": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiPressureChamberInterface": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiProgrammableController": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiProgrammer": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 51,
+                "bottom": -13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 51,
+                "bottom": -13
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 51,
+                "bottom": -13
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiRefineryController": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiSentryTurret": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiThermalCompressor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiThermopneumaticProcessingPlant": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiUniversalSensor": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiUVLightBox": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -10
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -22
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -34
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiVacuumPump": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiEtchingTank": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiReinforcedChest": {
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 116
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 116
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 116
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiTagWorkbench": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -4,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 8,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 20,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiFluidMixer": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiVacuumTrap": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -24
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -36
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiSpawnerExtractor": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.GuiPressurizedSpawner": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 20
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 20
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 20
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.PressurizedSpawnerScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.VacuumTrapScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.FluidMixerScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.TagWorkbenchScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -4,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -3,
+                "bottom": -11
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -2,
+                "bottom": -11
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.SmartChestScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.ReinforcedChestScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.EtchingTankScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.VacuumPumpScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.UVLightBoxScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.UniversalSensorScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.ThermopneumaticProcessingPlantScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.ThermalCompressorScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.SentryTurretScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.RefineryControllerScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.ProgrammerScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.ProgrammableControllerScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.PressureChamberInterfaceScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.PneumaticDynamoScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.PneumaticDoorBaseScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.OmnidirectionalHopperScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.LiquidHopperScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.LiquidCompressorScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.KeroseneLampScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.GasLiftScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.FluxCompressorScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.ElectrostaticCompressorScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.ChargingStationScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -41,
+                "bottom": -11
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -29,
+                "bottom": -23
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -17,
+                "bottom": -35
+            }
+        }
+    },
+    "me.desht.pneumaticcraft.client.gui.AssemblyControllerScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.AirCompressorScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.AirCannonScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.AerialInterfaceScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.AdvancedLiquidCompressorScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.AdvancedAirCompressorScreen": {
+        "playerSideOnly": true
+    },
+    "me.desht.pneumaticcraft.client.gui.semiblock.LogisticsRequesterScreen": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/productivebees.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/productivebees.json
@@ -1,0 +1,75 @@
+{
+    "cy.jdkdigital.productivebees.container.gui.CentrifugeScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 13
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 13
+            }
+        }
+    },
+    "cy.jdkdigital.productivebees.container.gui.BottlerScreen": {
+        "playerSideOnly": true
+    },
+    "cy.jdkdigital.productivebees.container.gui.IncubatorScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 10
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 10
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 10
+            }
+        }
+    },
+    "cy.jdkdigital.productivebees.container.gui.CatcherScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 13
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 13
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 13
+            }
+        }
+    },
+    "cy.jdkdigital.productivebees.container.gui.HoneyGeneratorScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 10
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 10
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 10
+            }
+        }
+    },
+    "cy.jdkdigital.productivebees.container.gui.GeneIndexerScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 40
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 40
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 40
+            }
+        }
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/rftoolsbase.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/rftoolsbase.json
@@ -1,0 +1,169 @@
+{
+    "mcjty.rftoolsbase.modules.infuser.client.GuiMachineInfuser": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbase.modules.crafting.client.GuiCraftingCard": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbase.modules.crafting.items.CraftingCardContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbase.modules.tablet.client.GuiTablet": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbase.modules.tablet.items.TabletContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbase.modules.filter.client.GuiFilterModule": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbase.modules.filter.items.FilterModuleContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.blazing.client.GuiBlazingGenerator": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.blazing.client.GuiBlazingAgitator": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.blazing.client.GuiBlazingInfuser": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.dimensionalcell.client.GuiDimensionalCell": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.endergenic.client.GuiEnderMonitor": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.endergenic.client.GuiPearlInjector": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.endergenic.client.GuiEndergenic": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.generator.client.GuiCoalGenerator": {
+        "ignore": true
+    },
+    "mcjty.rftoolspower.modules.monitor.client.GuiPowerMonitor": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbuilder.modules.builder.client.GuiBuilder": {
+        "ignore": true
+    },
+    "mcjty.rftoolsbuilder.modules.shield.client.GuiShield": {
+        "ignore": true
+    },
+    "mcjty.xnet.modules.controller.client.GuiController": {
+        "ignore": true
+    },
+    "mcjty.xnet.modules.router.client.GuiRouter": {
+        "ignore": true
+    },
+    "mcjty.xnet.modules.wireless.client.GuiWirelessRouter": {
+        "ignore": true
+    },
+    "mcjty.rftoolsstorage.modules.craftingmanager.client.GuiCraftingManager": {
+        "ignore": true
+    },
+    "mcjty.rftoolsstorage.modules.craftingmanager.blocks.CraftingManagerContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsstorage.modules.modularstorage.client.GuiModularStorage": {
+        "ignore": true
+    },
+    "mcjty.rftoolsstorage.modules.modularstorage.blocks.ModularStorageContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsstorage.modules.scanner.client.GuiStorageScanner": {
+        "ignore": true
+    },
+    "mcjty.rftoolsstorage.modules.scanner.blocks.StorageScannerContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolscontrol.modules.craftingstation.client.GuiCraftingStation": {
+        "ignore": true
+    },
+    "mcjty.rftoolscontrol.modules.multitank.client.GuiMultiTank": {
+        "ignore": true
+    },
+    "mcjty.rftoolscontrol.modules.processor.client.GuiProcessor": {
+        "ignore": true
+    },
+    "mcjty.rftoolscontrol.modules.programmer.client.GuiProgrammer": {
+        "ignore": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": -42,
+                "bottom": -14
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": -30,
+                "bottom": -26
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": -18,
+                "bottom": -38
+            }
+        }
+    },
+    "mcjty.rftoolscontrol.modules.various.client.GuiNode": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiAnalog": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiInvChecker": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiCounter": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiSensor": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiSequencer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiThreeLogic": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiTimer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiRedstoneReceiver": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.logic.client.GuiRedstoneTransmitter": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.screen.client.GuiScreenController": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.screen.client.GuiScreen": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.screen.blocks.ScreenContainer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.spawner.client.GuiMatterBeamer": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.spawner.client.GuiSpawner": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.tank.client.GuiTank": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.teleporter.client.GuiMatterTransmitter": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.teleporter.client.GuiMatterReceiver": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.teleporter.client.GuiDialingDevice": {
+        "ignore": true
+    },
+    "mcjty.rftoolsutility.modules.environmental.client.GuiEnvironmentalController": {
+        "ignore": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/sophisticatedbackpacks.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/sophisticatedbackpacks.json
@@ -1,0 +1,18 @@
+{
+    "net.p3pp3rf1y.sophisticatedbackpacks.client.gui.BackpackScreen": {
+        "buttonHints": {
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": 30
+            },
+            "SORT": {
+                "horizontalOffset": 30
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 30
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 30
+            }
+        }
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/sophisticatedstorage.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/sophisticatedstorage.json
@@ -1,0 +1,21 @@
+{
+    "net.p3pp3rf1y.sophisticatedstorage.client.gui.StorageScreen": {
+        "buttonHints": {
+            "MOVE_TO_PLAYER": {
+                "horizontalOffset": 28
+            },
+            "SORT": {
+                "horizontalOffset": 25
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 26
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 27
+            }
+        }
+    },
+    "net.p3pp3rf1y.sophisticatedstorage.common.gui.StorageContainerMenu": {
+        "ignore": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/supplementaries.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/supplementaries.json
@@ -1,0 +1,21 @@
+{
+    "net.mehvahdjukaar.supplementaries.client.gui.TrappedPresentBlockGui": {
+        "playerSideOnly": true
+    },
+    "shadows.apotheosis.ench.library.EnchLibraryScreen": {
+        "playerSideOnly": true
+    },
+    "net.mehvahdjukaar.supplementaries.client.gui.PresentBlockGui": {
+        "ignore": true,
+        "playerSideOnly": true
+    },
+    "net.mehvahdjukaar.supplementaries.client.gui.NoticeBoardGui": {
+        "playerSideOnly": true
+    },
+    "net.mehvahdjukaar.supplementaries.client.gui.PulleyBlockGui": {
+        "playerSideOnly": true
+    },
+    "net.mehvahdjukaar.supplementaries.client.gui.SackGui": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/tconstruct.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/tconstruct.json
@@ -1,0 +1,69 @@
+{
+    "slimeknights.tconstruct.tables.client.inventory.table.CraftingStationScreen": {
+        "playerSideOnly": true
+    },
+    "slimeknights.tconstruct.tables.client.inventory.table.TinkerStationScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 50
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 50
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 50
+            }
+        }
+    },
+    "slimeknights.tconstruct.tables.client.inventory.table.PartBuilderScreen": {
+        "playerSideOnly": true
+    },
+    "slimeknights.tconstruct.tables.client.inventory.TinkerStationScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SORT": {
+                "horizontalOffset": 40,
+                "bottom": 2
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 40,
+                "bottom": 2
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 40,
+                "bottom": 2
+            }
+        }
+    },
+    "slimeknights.tconstruct.tables.client.inventory.PartBuilderScreen": {
+        "playerSideOnly": true
+    },
+    "slimeknights.tconstruct.tables.client.inventory.CraftingStationScreen": {
+        "buttonHints": {
+            "CONTINUOUS_CRAFTING": {
+                "horizontalOffset": 50,
+                "bottom": -17
+            },
+            "PROFILE_SELECTOR": {
+                "hide": true
+            },
+            "MOVE_TO_CONTAINER": {
+                "bottom": -12
+            },
+            "SORT": {
+                "horizontalOffset": 12
+            },
+            "SORT_COLUMNS": {
+                "horizontalOffset": 12
+            },
+            "SORT_ROWS": {
+                "horizontalOffset": 12
+            }
+        }
+    },
+    "slimeknights.tconstruct.tables.menu.CraftingStationContainerMenu": {
+        "playerSideOnly": true,
+        "force": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/integrationHints/thermal.json
+++ b/overrides/config/inventoryprofilesnext/integrationHints/thermal.json
@@ -1,0 +1,109 @@
+{
+    "cofh.thermal.expansion.client.gui.machine.MachineFurnaceScreen": {
+        "playerSideOnly": true,
+        "buttonHints": {
+            "SHOW_EDITOR": {
+                "horizontalOffset": 2
+            }
+        }
+    },
+    "cofh.thermal.core.client.gui.device.DeviceHiveExtractorScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceTreeExtractorScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceFisherScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceSoilInfuserScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceWaterGenScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceRockGenScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceCollectorScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DevicePotionDiffuserScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.device.DeviceNullifierScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.TinkerBenchScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.ChargeBenchScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.storage.EnergyCellScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.core.client.gui.storage.FluidCellScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineSawmillScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachinePulverizerScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineSmelterScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineInsolatorScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineCentrifugeScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachinePressScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineCrucibleScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineChillerScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineRefineryScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachinePyrolyzerScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineBottlerScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineBrewerScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.machine.MachineCrafterScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoStirlingScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoCompressionScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoNumismaticScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoMagmaticScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoLapidaryScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoDisenchantmentScreen": {
+        "playerSideOnly": true
+    },
+    "cofh.thermal.expansion.client.gui.dynamo.DynamoGourmandScreen": {
+        "playerSideOnly": true
+    }
+}

--- a/overrides/config/inventoryprofilesnext/inventoryprofiles.json
+++ b/overrides/config/inventoryprofilesnext/inventoryprofiles.json
@@ -1,5 +1,72 @@
 {
-  "ModSettings": {
-    "first_run": false
-  }
+    "ModSettings": {
+        "highlight_foused_items": {
+            "value": false
+        },
+        "enable_lock_slots": {
+            "value": false
+        },
+        "enable_lock_slots_per_server": false,
+        "first_run": false
+    },
+    "GuiSettings": {
+        "enable_inventory_editor_button": {
+            "value": false
+        },
+        "enable_profiles_ui": {
+            "value": false
+        },
+        "continuous_crafting_saved_value": false
+    },
+    "LockedSlotsSettings": {
+        "lock_slots_switch_config_modifier": {
+            "main": {
+                "keys": ""
+            }
+        },
+        "show_locked_slots_background": {
+            "value": false
+        },
+        "show_locked_slots_foreground": {
+            "value": false
+        },
+        "also_show_locked_slots_in_hotbar": {
+            "value": false
+        }
+    },
+    "AutoRefillSettings": {
+        "tool_damage_threshold": 0,
+        "audio_durability_notification": {
+            "value": false
+        },
+        "visual_replace_success_notification": {
+            "value": false
+        },
+        "audio_replace_success_notification": {
+            "value": false
+        },
+        "visual_replace_failed_notification": {
+            "value": false
+        },
+        "audio_replace_failed_notification": {
+            "value": false
+        }
+    },
+    "Hotkeys": {
+        "sort_inventory": {
+            "main": {
+                "keys": ""
+            }
+        },
+        "scroll_to_chest": {
+            "main": {
+                "keys": ""
+            }
+        },
+        "scroll_to_inventory": {
+            "main": {
+                "keys": ""
+            }
+        }
+    }
 }


### PR DESCRIPTION
Included mod settings:
- Applied energistics 2
- Astral sorcery
- Chisel and bits
- Cyclic
- Extended crafting
- Farming for blockheads
- Immersive engineering
- Integrated dynamics
- Iron chest
- Mekanism
- Pneumaticcraft
- Productive bees
- RFtools
- Sophisticated storage + backpacks
- Supplementaries
- Tinker's construct
- Thermal 
- Lazier AE2
- Apotheosis
- AE2 wireless terminal
- Avaritia
- Better crates
- Blood magic
- Draconic evolution
- Ender storage
- Environmental tech
- Titanium
- Inspirations
- Mob grinding utils
- More minecarts
- MrCrayFish furniture
- Oh the biomes you'll go
- Powah
- RFtools utility
- Securitycraft
- Storage drawers
- Mantle
- Atum
- Prehistoric fauna
- Gaia dimension
- AE additions
- Refined pipes
- Boss tools
- Storage network
- Dank storage